### PR TITLE
Set Guice class loading to CHILD - avoid using terminally deprecated methods

### DIFF
--- a/src/main/java/org/codehaus/plexus/testing/PlexusExtension.java
+++ b/src/main/java/org/codehaus/plexus/testing/PlexusExtension.java
@@ -71,6 +71,12 @@ public class PlexusExtension implements BeforeEachCallback, AfterEachCallback {
 
     private static String basedir;
 
+    static {
+        if (System.getProperty("guice_custom_class_loading", "").trim().isEmpty()) {
+            System.setProperty("guice_custom_class_loading", "CHILD");
+        }
+    }
+
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
         basedir = getBasedir();


### PR DESCRIPTION

Default Guice class loading uses a terminally deprecated JDK memory-access classes.