### PR TITLE
Establish an automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,17 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.plexus.testing</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-publish-plugin</artifactId>
         <configuration>
           <content>${project.reporting.outputDirectory}</content>


### PR DESCRIPTION
`org.codehaus.plexus.testing` — the artifact's top-level package. Set through `maven-jar-plugin` `manifestEntries`, as plexus-utils does; same pattern as codehaus-plexus/plexus-xml#92.

Verified: `jar --describe-module` reports `org.codehaus.plexus.testing@2.1.1-SNAPSHOT automatic`.

*This change was created with AI assistance.*